### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/content/Method/Anisotropy.md
+++ b/content/Method/Anisotropy.md
@@ -43,11 +43,11 @@ title: 各向异性
 
 ### 切向能量最小法
 
-[Silver & Chan, 1991, JGR](http://dx.doi.org/10.1029/91jb00899)
+[Silver & Chan, 1991, JGR](https://doi.org/10.1029/91jb00899)
 
 ### Splitting Intensity
 
-[Chevrot, 2000, JGR](http://dx.doi.org/10.1029/2000JB900199)
+[Chevrot, 2000, JGR](https://doi.org/10.1029/2000JB900199)
 
 ### 互相关法
 

--- a/content/Method/receiver-function.md
+++ b/content/Method/receiver-function.md
@@ -166,7 +166,7 @@ $$ t_{Ps-P} = H * (\sqrt{\frac{1}{V_s^2}-p^2} - \sqrt{\frac{1}{V_p^2}-p^2}) $$
 
 ### h-k 法
 
-[Zhu & Kanamori, 2000, JGR](http://dx.doi.org/10.1029/1999JB900322)
+[Zhu & Kanamori, 2000, JGR](https://doi.org/10.1029/1999JB900322)
 
 如果只使用 Ps-P 走时差，由于 Moho深度与 Vp/Vs 存在 trade-off，所以无法约束介质结构。
 
@@ -231,7 +231,7 @@ S波接收函数的原理与P接收函数的原理类似，其优点在于Moho�
 
 ## 参考文献
 
-1. [Zhu & Kanamori, 2000, JGR](http://dx.doi.org/10.1029/1999JB900322)
+1. [Zhu & Kanamori, 2000, JGR](https://doi.org/10.1029/1999JB900322)
 2. [Ligorría & Ammon, 1999, BSSA](http://www.bssaonline.org/content/89/5/1395.short)
-3. [Zhu, 2000, EPSL](http://dx.doi.org/10.1016/S0012-821X(00)00101-1)
-4. [Yuan et. al., 2006, GJI](http://dx.doi.org/10.1111/j.1365-246X.2006.02885.x)
+3. [Zhu, 2000, EPSL](https://doi.org/10.1016/S0012-821X(00)00101-1)
+4. [Yuan et. al., 2006, GJI](https://doi.org/10.1111/j.1365-246X.2006.02885.x)

--- a/content/Python/web.md
+++ b/content/Python/web.md
@@ -17,7 +17,7 @@ title: 网络相关
 # source: https://gist.github.com/jrsmith3/5513926
 
 import requests
-url = "http://dx.doi.org/10.1038/nature07109"
+url = "https://doi.org/10.1038/nature07109"
 
 headers = {"accept": "application/x-bibtex"}
 r = requests.get(url, headers=headers)

--- a/themes/hugo-theme-wiki/layouts/shortcodes/paper.html
+++ b/themes/hugo-theme-wiki/layouts/shortcodes/paper.html
@@ -1,1 +1,1 @@
-<a href="http://dx.doi.org/{{ .Get 1 }}">{{ .Get 0 }}</a>
+<a href="https://doi.org/{{ .Get 1 }}">{{ .Get 0 }}</a>


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

Although there is no urgent need to do anything, I'd hereby like to suggest to follow the new recommendation and update all static DOI links and any code that hyperlinks DOIs.

Cheers!